### PR TITLE
Update README with proper gem declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Parse OPML into a flat hash. OPML Saw supports nesting (folders) through the tag
 
 Add this line to your application's Gemfile:
 
-    gem 'opml_saw'
+    gem 'opml_saw', :git => "git://github.com/feedbin/opml_saw.git", :branch => "master"
 
 And then execute:
 


### PR DESCRIPTION
Just providing `gem 'opml_saw'` does not work. It will fail saying the gem doesn't exist. You need to supply the git repository.
